### PR TITLE
Fix: incorrect autosave on session switch from a starting screen

### DIFF
--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -28,14 +28,7 @@ function session_manager.autosave_session()
     return
   end
 
-  if config.autosave_ignore_not_normal then
-    for _, buffer in ipairs(vim.api.nvim_list_bufs()) do
-      if vim.api.nvim_buf_is_valid(buffer) and utils.is_normal_buffer(buffer) then
-        session_manager.save_current_session()
-        return
-      end
-    end
-  else
+  if not config.autosave_ignore_not_normal or utils.normal_buffer_present() then
     session_manager.save_current_session()
   end
 end

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -122,4 +122,13 @@ function utils.is_normal_buffer(buffer)
   return #vim.api.nvim_buf_get_option(buffer, 'buftype') == 0 and vim.api.nvim_buf_get_option(buffer, 'buflisted')
 end
 
+function utils.normal_buffer_present()
+  for _, buffer in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(buffer) and utils.is_normal_buffer(buffer) then
+      return true
+    end
+  end
+  return false
+end
+
 return utils

--- a/lua/telescope/_extensions/sessions.lua
+++ b/lua/telescope/_extensions/sessions.lua
@@ -6,6 +6,7 @@ local finders = require('telescope.finders')
 local sorters = require('telescope.sorters')
 local themes = require('telescope.themes')
 local utils = require('session_manager.utils')
+local config = require('session_manager.config')
 local Path = require('plenary.path')
 
 local function select_session(opts)
@@ -30,7 +31,7 @@ local function select_session(opts)
         actions.close(prompt_bufnr)
         local entry = state.get_selected_entry()
         if entry then
-          if opts['save_current'] then
+          if opts['save_current'] and (not config.autosave_ignore_not_normal or utils.normal_buffer_present()) then
             utils.save_session(utils.dir_to_session_filename())
           end
           utils.load_session(entry.value)


### PR DESCRIPTION
I have noticed that when I'm trying to open a session of a folder that I'm currently in from a start screen (Alpha, Dashboard or any other, probably) Telescope opens an empty buffer. The `save_current` and the `autosave_ignore_not_normal` options  are `true`.

This fixes that behavior.