### PR TITLE
Add autosave_ignore_filetypes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ require('session_manager').setup({
   autoload_mode = require('session_manager.config').AutoloadMode.LastSession, -- Define what to do when Neovim is started without arguments. Possible values: Disabled, CurrentDir, LastSession
   autosave_last_session = true, -- Automatically save last session on exit and on session switch.
   autosave_ignore_not_normal = true, -- Plugin will not save a session when no writable and listed buffers are opened.
+  autosave_ignore_filetypes = { -- These filetypes will be ignored when autosaving; needs autosave_ignore_not_normal = true
+    'gitcommit'
+  }, 
   autosave_only_in_session = false, -- Always autosaves session. If true, only autosaves after a session is active.
 })
 ```

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ require('session_manager').setup({
   autoload_mode = require('session_manager.config').AutoloadMode.LastSession, -- Define what to do when Neovim is started without arguments. Possible values: Disabled, CurrentDir, LastSession
   autosave_last_session = true, -- Automatically save last session on exit and on session switch.
   autosave_ignore_not_normal = true, -- Plugin will not save a session when no writable and listed buffers are opened.
-  autosave_ignore_filetypes = { -- These filetypes will be ignored when autosaving; needs autosave_ignore_not_normal = true
-    'gitcommit'
+  autosave_ignore_filetypes = { -- These filetypes will be ignored when autosaving; works best with autosave_ignore_not_normal = true
+    'gitcommit',
   }, 
   autosave_only_in_session = false, -- Always autosaves session. If true, only autosaves after a session is active.
 })

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ require('session_manager').setup({
   colon_replacer = '++', -- The character to which the colon symbol will be replaced for session files.
   autoload_mode = require('session_manager.config').AutoloadMode.LastSession, -- Define what to do when Neovim is started without arguments. Possible values: Disabled, CurrentDir, LastSession
   autosave_last_session = true, -- Automatically save last session on exit and on session switch.
-  autosave_ignore_not_normal = true, -- Plugin will not save a session when no writable and listed buffers are opened.
-  autosave_ignore_filetypes = { -- These filetypes will be ignored when autosaving; works best with autosave_ignore_not_normal = true
+  autosave_ignore_not_normal = true, -- Plugin will not save a session when no buffers are opened, or all of them aren't writable or listed.
+  autosave_ignore_filetypes = { -- All buffers of these file types will be closed before the session is saved.
     'gitcommit',
   }, 
   autosave_only_in_session = false, -- Always autosaves session. If true, only autosaves after a session is active.

--- a/lua/session_manager/config.lua
+++ b/lua/session_manager/config.lua
@@ -16,6 +16,9 @@ config.defaults = {
   autoload_mode = config.AutoloadMode.LastSession,
   autosave_last_session = true,
   autosave_ignore_not_normal = true,
+  autosave_ignore_filetypes = {
+    'gitcommit'
+  },
   autosave_only_in_session = false,
 }
 

--- a/lua/session_manager/config.lua
+++ b/lua/session_manager/config.lua
@@ -17,7 +17,7 @@ config.defaults = {
   autosave_last_session = true,
   autosave_ignore_not_normal = true,
   autosave_ignore_filetypes = {
-    'gitcommit'
+    'gitcommit',
   },
   autosave_only_in_session = false,
 }

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -125,7 +125,19 @@ function utils.dir_to_session_filename(dir)
 end
 
 function utils.is_normal_buffer(buffer)
-  return #vim.api.nvim_buf_get_option(buffer, 'buftype') == 0 and vim.api.nvim_buf_get_option(buffer, 'buflisted')
+  local buftype = vim.api.nvim_buf_get_option(buffer, 'buftype')
+  local buflisted = vim.api.nvim_buf_get_option(buffer, 'buflisted')
+  local filetype = vim.api.nvim_buf_get_option(buffer, 'filetype')
+  return #buftype == 0 and buflisted and utils.is_normal_filetype(filetype)
+end
+
+function utils.is_normal_filetype(filetype)
+  for i, v in pairs(config.autosave_ignore_filetypes) do
+    if (v == filetype) then
+      return false
+    end
+  end
+  return true
 end
 
 function utils.is_normal_buffer_present()

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -125,19 +125,10 @@ function utils.dir_to_session_filename(dir)
 end
 
 function utils.is_normal_buffer(buffer)
-  local buftype = vim.api.nvim_buf_get_option(buffer, 'buftype')
-  local buflisted = vim.api.nvim_buf_get_option(buffer, 'buflisted')
-  local filetype = vim.api.nvim_buf_get_option(buffer, 'filetype')
-  return #buftype == 0 and buflisted and utils.is_normal_filetype(filetype)
-end
-
-function utils.is_normal_filetype(filetype)
-  for i, v in pairs(config.autosave_ignore_filetypes) do
-    if (v == filetype) then
-      return false
-    end
-  end
-  return true
+  local is_normal_buftype = #vim.api.nvim_buf_get_option(buffer, 'buftype') == 0
+  local is_buflisted = vim.api.nvim_buf_get_option(buffer, 'buflisted')
+  local is_normal_filetype = not vim.tbl_contains(config.autosave_ignore_filetypes, vim.api.nvim_buf_get_option(buffer, 'filetype'))
+  return is_normal_buftype and is_buflisted and is_normal_filetype
 end
 
 function utils.is_normal_buffer_present()

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -125,10 +125,15 @@ function utils.dir_to_session_filename(dir)
 end
 
 function utils.is_normal_buffer(buffer)
-  local is_normal_buftype = #vim.api.nvim_buf_get_option(buffer, 'buftype') == 0
-  local is_buflisted = vim.api.nvim_buf_get_option(buffer, 'buflisted')
-  local is_normal_filetype = not vim.tbl_contains(config.autosave_ignore_filetypes, vim.api.nvim_buf_get_option(buffer, 'filetype'))
-  return is_normal_buftype and is_buflisted and is_normal_filetype
+  if #vim.api.nvim_buf_get_option(buffer, 'buftype') ~= 0 then
+      return false
+  end
+  if not vim.api.nvim_buf_get_option(buffer, 'buflisted') then
+      return false
+  end
+  if vim.tbl_contains(config.autosave_ignore_filetypes, vim.api.nvim_buf_get_option(buffer, 'filetype')) then
+      return false
+  return true
 end
 
 function utils.is_normal_buffer_present()

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -126,13 +126,12 @@ end
 
 function utils.is_normal_buffer(buffer)
   if #vim.api.nvim_buf_get_option(buffer, 'buftype') ~= 0 then
-      return false
+    return false
+  elseif not vim.api.nvim_buf_get_option(buffer, 'buflisted') then
+    return false
+  elseif vim.tbl_contains(config.autosave_ignore_filetypes, vim.api.nvim_buf_get_option(buffer, 'filetype')) then
+    return false
   end
-  if not vim.api.nvim_buf_get_option(buffer, 'buflisted') then
-      return false
-  end
-  if vim.tbl_contains(config.autosave_ignore_filetypes, vim.api.nvim_buf_get_option(buffer, 'filetype')) then
-      return false
   return true
 end
 


### PR DESCRIPTION
Hi Shatur,

i added a new option 'autosave_ignore_filetypes'. The configured filetypes will be ignored when autosaving a session.
This fixes #19

Currently it will only work correctly when autosave_ignore_not_normal is set to true.
Otherwise (in the example of 'gitcommit') a empty session will be saved.

Hope this helps!