### PR TITLE
add config option autosave_if_argc

### DIFF
--- a/lua/session_manager/config.lua
+++ b/lua/session_manager/config.lua
@@ -20,6 +20,7 @@ config.defaults = {
     'gitcommit',
   },
   autosave_only_in_session = false,
+  autosave_if_argc = false,
   max_path_length = 80,
 }
 

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -88,6 +88,10 @@ function session_manager.autosave_session()
     return
   end
 
+  if not config.autosave_if_argc and vim.fn.argc() ~= 0 then
+    return
+  end
+
   if not config.autosave_ignore_not_normal or utils.is_restorable_buffer_present() then
     session_manager.save_current_session()
   end


### PR DESCRIPTION
If neovim is opened with a file, then it is maybe temporary and the user may not want it to affect the current session, so add config option "autosave_if_argc" to let the user determine it.