### PR TITLE
Properly stop all LSP clients

### DIFF
--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -44,7 +44,9 @@ function utils.load_session(filename, discard_current)
   end
 
   -- Stop all LSP clients first
-  vim.lsp.stop_client(vim.lsp.get_active_clients())
+  for _, client in pairs(vim.lsp.get_active_clients()) do
+    vim.lsp.stop_client(client)
+  end
 
   -- Scedule buffers cleanup to avoid callback issues and source the session
   vim.schedule(function()


### PR DESCRIPTION
Trying to use the session manager (which I love by the way!) while also using `copilot.vim` I noticed `copilot.vim` crashed and didn't recover every time after loading a session. After investigating this turned out to be the fix...