### PR TITLE
Draw: Keep ui-select open when deleting a session

### DIFF
--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -74,6 +74,7 @@ function session_manager.delete_session()
     if idx then
       Path:new(sessions[idx].filename):rm()
     end
+    session_manager.delete_session()
   end)
 end
 

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -73,8 +73,8 @@ function session_manager.delete_session()
   vim.ui.select(display_names, { prompt = 'Delete session' }, function(_, idx)
     if idx then
       Path:new(sessions[idx].filename):rm()
+      session_manager.delete_session()
     end
-    session_manager.delete_session()
   end)
 end
 


### PR DESCRIPTION
A simple solution but why not use it.

I prefer this as the default but that's probably just my opinion.
Maybe implement this behavior as an option?

What do you think?