### PR TITLE
fix: Minor Neovim API discrepency in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ For example, if you would like to have NvimTree or any other file tree automatic
 ```lua
 local config_group = vim.api.nvim_create_augroup('MyConfigGroup', {}) -- A global group for all your config autocommands
 
-vim.api.nvim_create_autocmd({ 'SessionLoadPost' }, {
+vim.api.nvim_create_autocmd({ 'User' }, {
+  pattern = "SessionLoadPost",
   group = config_group,
   callback = function()
     require('nvim-tree').toggle(false, true)


### PR DESCRIPTION
I tried adding the excerpt from your README into my own Neovim setup and I was getting errors when trying to duplicate it for the `SessionSavePost` event. After about thirty minutes of crawling the documentation, I realized that the implementation is *vaguely* wrong based on it's use-case. For user generated **autocmd**s, users should use the `User` [event](https://neovim.io/doc/user/autocmd.html#{event}), and supply the event name they wish to listen for through the `pattern` option. I've tested this on my machine and it works for both the `SessionSavePost` and `SessionLoadPost` events.