### PR TITLE
Require buffer to have a filename to be restorable

### DIFF
--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -149,6 +149,10 @@ function utils.is_restorable(buffer)
     if not vim.api.nvim_buf_get_option(buffer, 'buflisted') then
       return false
     end
+    -- Check if it has a filename.
+    if #vim.api.nvim_buf_get_name(buffer) == 0 then
+      return false
+    end
   elseif buftype ~= 'terminal' then
     -- Buffers other then normal or terminal are impossible to restore.
     return false


### PR DESCRIPTION
This avoids creating empty sessions if the user runs `vim` and quits after some scratch editing.  Also avoids ruining existing sessions when the user runs `vim -`.