### PR TITLE
Do not shorten the path completely

### DIFF
--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -196,7 +196,7 @@ end
 function utils.shorten_path(filename)
   -- Shorten path if length exceeds defined max_path_length.
   if config.max_path_length > 0 and #filename > config.max_path_length then
-    local excludes = { -1 }  -- index to exclude from shortening, -1 means last
+    local excludes = { -1 }  -- Index to exclude from shortening, -1 means last
     local shortened = nil
 
     -- Gradually increase the tailing excludes

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -196,13 +196,23 @@ end
 function utils.shorten_path(filename)
   -- Shorten path if length exceeds defined max_path_length.
   if config.max_path_length > 0 and #filename > config.max_path_length then
-    local excludes = { -1 }  -- Index to exclude from shortening, -1 means last
-    local shortened = nil
+    -- Index to exclude from shortening, -1 means last
+    local excludes = { -1 }
+
+    -- Final shortened path to return, return original filename if cannot shorten
+    local shortened = filename
+
+    -- Cache the shortest version
+    local cached = Path:new(filename):shorten(1, excludes)
 
     -- Gradually increase the tailing excludes
-    while string.len(Path:new(filename):shorten(1, excludes)) < config.max_path_length do
-      shortened = Path:new(filename):shorten(1, excludes)
+    while string.len(cached) < config.max_path_length do
+      -- Store the cached path
+      shortened = cached
+
+      -- Try to cache new shortened path with more excludes
       excludes[#excludes + 1] = excludes[#excludes] - 1
+      cached = Path:new(filename):shorten(1, excludes)
     end
 
     return shortened

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -196,13 +196,13 @@ end
 function utils.shorten_path(filename)
   -- Shorten path if length exceeds defined max_path_length.
   if config.max_path_length > 0 and #filename > config.max_path_length then
-    local excludes = {-1}  -- index to exclude from shortening, -1 means last
+    local excludes = { -1 }  -- index to exclude from shortening, -1 means last
     local shortened = nil
 
     -- Gradually increase the tailing excludes
     while string.len(Path:new(filename):shorten(1, excludes)) < config.max_path_length do
       shortened = Path:new(filename):shorten(1, excludes)
-      excludes[#excludes+1] = excludes[#excludes] - 1
+      excludes[#excludes + 1] = excludes[#excludes] - 1
     end
 
     return shortened

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -196,7 +196,16 @@ end
 function utils.shorten_path(filename)
   -- Shorten path if length exceeds defined max_path_length.
   if config.max_path_length > 0 and #filename > config.max_path_length then
-    return Path:new(filename):shorten()
+    local excludes = {-1}  -- index to exclude from shortening, -1 means last
+    local shortened = nil
+
+    -- Gradually increase the tailing excludes
+    while string.len(Path:new(filename):shorten(1, excludes)) < config.max_path_length do
+      shortened = Path:new(filename):shorten(1, excludes)
+      excludes[#excludes+1] = excludes[#excludes] - 1
+    end
+
+    return shortened
   end
 
   -- Otherwise, use original path.


### PR DESCRIPTION
The old shorten_path function will completely reduce the path as soon as it exceeds config.max_path_length, e.g., `/dir1/dir2/dir3/dir4/dir5/dir6/filename` will become `/d/d/d/d/d/d/filename`, which may be too short. The new implementation ensures that the tailing directories are excluded, as long as the shortened path does not exceed the limit, e.g., `/d/d/d/d/dir5/dir6/filename`.