### PR TITLE
Add feature to avoid autosaving in certain folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ require('session_manager').setup({
   autoload_mode = require('session_manager.config').AutoloadMode.LastSession, -- Define what to do when Neovim is started without arguments. Possible values: Disabled, CurrentDir, LastSession
   autosave_last_session = true, -- Automatically save last session on exit and on session switch.
   autosave_ignore_not_normal = true, -- Plugin will not save a session when no buffers are opened, or all of them aren't writable or listed.
+  autosave_ignore_dirs = {}, -- A list of directories where the session will not be autosaved.
   autosave_ignore_filetypes = { -- All buffers of these file types will be closed before the session is saved.
     'gitcommit',
   },

--- a/lua/session_manager/config.lua
+++ b/lua/session_manager/config.lua
@@ -16,6 +16,7 @@ config.defaults = {
   autoload_mode = config.AutoloadMode.LastSession,
   autosave_last_session = true,
   autosave_ignore_not_normal = true,
+  autosave_ignore_dirs = {},
   autosave_ignore_filetypes = {
     'gitcommit',
   },

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -83,6 +83,10 @@ function session_manager.autosave_session()
     return
   end
 
+  if config.autosave_ignore_dirs and utils.is_dir_in_ignore_list() then
+    return
+  end
+
   if not config.autosave_ignore_not_normal or utils.is_restorable_buffer_present() then
     session_manager.save_current_session()
   end

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -191,6 +191,14 @@ function utils.is_restorable_buffer_present()
   return false
 end
 
+---@return boolean
+function utils.is_dir_in_ignore_list()
+  local cwd = vim.loop.cwd()
+  local function contains(dir) return vim.tbl_contains(config.autosave_ignore_dirs, dir) end
+
+  return contains(cwd) or contains(vim.fn.fnamemodify(cwd, ':~'))
+end
+
 --- Partially shorten path if length exceeds defined max_path_length.
 ---@param path table
 ---@return string


### PR DESCRIPTION
Adds a feature to avoid autosaving in certain folders, as had been suggested as an alternative solution for #14.

By default, this will only avoid autosaving when in `~`, but other folders can be added in the user's config.

Any directories added to the filter list will not delete existing sessions saved for those folders, so the user would need to manually remove those afterwards if desired.