### PR TITLE
fix path for autosaving sessions

### DIFF
--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -150,7 +150,7 @@ function utils.dir_to_session_filename(dir)
   local filename = dir and dir.filename or vim.loop.cwd()
   filename = filename:gsub(':', config.colon_replacer)
   filename = filename:gsub(Path.path.sep, config.path_replacer)
-  return Path:new(config.sessions_dir):joinpath(filename)
+  return Path:new(tostring(config.sessions_dir)):joinpath(filename)
 end
 
 ---@param buffer number: buffer ID.


### PR DESCRIPTION
I didn't catch what was updated on my system, but for now it works only that way: convert sessions_dir to string as it was done in other code chunks. 
Without this PR change plugin tries to save sessions in / (root) directory and obviously can't do it. 

Neovim version 0.8.0, Arch Linux