### PR TITLE
Extendable Extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ To configure the plugin, you can call `require('session_manager').setup(values)`
 local Path = require('plenary.path')
 require('session_manager').setup({
   sessions_dir = Path:new(vim.fn.stdpath('data'), 'sessions'), -- The directory where the session files will be saved.
-  path_replacer = '__', -- The character to which the path separator will be replaced for session files.
-  colon_replacer = '++', -- The character to which the colon symbol will be replaced for session files.
   autoload_mode = require('session_manager.config').AutoloadMode.LastSession, -- Define what to do when Neovim is started without arguments. Possible values: Disabled, CurrentDir, LastSession
   autosave_last_session = true, -- Automatically save last session on exit and on session switch.
   autosave_ignore_not_normal = true, -- Plugin will not save a session when no buffers are opened, or all of them aren't writable or listed.

--- a/lua/session_manager/config.lua
+++ b/lua/session_manager/config.lua
@@ -14,7 +14,6 @@ local config = {
 ---@return string: Session directory
 function config.delimited_session_filename_to_dir(filename)
   local dir = filename
-  dir = dir:sub(0, dir:find(config.colon_replacer))
   dir = dir:gsub(config.colon_replacer, ':')
   dir = dir:gsub(config.path_replacer, Path.path.sep)
   return dir
@@ -27,12 +26,6 @@ function config.dir_to_delimited_session_filename(dir)
   local filename = dir
   filename = filename:gsub(':', config.colon_replacer)
   filename = filename:gsub(Path.path.sep, config.path_replacer)
-
-  local extras = config.extras_generator(dir)
-  if extras ~= nil then
-    filename = filename .. config.extras_separator .. extras
-  end
-
   return filename
 end
 
@@ -42,8 +35,6 @@ config.defaults = {
   colon_replacer = '++',
   dir_to_session_filename = config.dir_to_delimited_session_filename,
   session_filename_to_dir = config.delimited_session_filename_to_dir,
-  extras_separator = '==',
-  extras_generator = function (dir) return nil end,
   autoload_mode = config.AutoloadMode.LastSession,
   autosave_last_session = true,
   autosave_ignore_not_normal = true,

--- a/lua/session_manager/config.lua
+++ b/lua/session_manager/config.lua
@@ -9,13 +9,16 @@ local config = {
   }),
 }
 
+local PATH_REPLACER = '__'
+local COLON_REPLACER = '++'
+
 --- Replaces symbols into separators and colons to transform filename into a session directory.
 ---@param filename string: Filename with expressions to replace.
 ---@return string: Session directory
 function config.delimited_session_filename_to_dir(filename)
   local dir = filename
-  dir = dir:gsub(config.colon_replacer, ':')
-  dir = dir:gsub(config.path_replacer, Path.path.sep)
+  dir = dir:gsub(COLON_REPLACER, ':')
+  dir = dir:gsub(PATH_REPLACER, Path.path.sep)
   return dir
 end
 
@@ -24,15 +27,13 @@ end
 ---@return string: Session filename.
 function config.dir_to_delimited_session_filename(dir)
   local filename = dir
-  filename = filename:gsub(':', config.colon_replacer)
-  filename = filename:gsub(Path.path.sep, config.path_replacer)
+  filename = filename:gsub(':', COLON_REPLACER)
+  filename = filename:gsub(Path.path.sep, PATH_REPLACER)
   return filename
 end
 
 config.defaults = {
   sessions_dir = Path:new(vim.fn.stdpath('data'), 'sessions'),
-  path_replacer = '__',
-  colon_replacer = '++',
   dir_to_session_filename = config.dir_to_delimited_session_filename,
   session_filename_to_dir = config.delimited_session_filename_to_dir,
   autoload_mode = config.AutoloadMode.LastSession,

--- a/lua/session_manager/config.lua
+++ b/lua/session_manager/config.lua
@@ -13,6 +13,8 @@ config.defaults = {
   sessions_dir = Path:new(vim.fn.stdpath('data'), 'sessions'),
   path_replacer = '__',
   colon_replacer = '++',
+  extras_separator = '==',
+  extras_generator = function (dir) return nil end,
   autoload_mode = config.AutoloadMode.LastSession,
   autosave_last_session = true,
   autosave_ignore_not_normal = true,

--- a/lua/session_manager/config.lua
+++ b/lua/session_manager/config.lua
@@ -9,10 +9,39 @@ local config = {
   }),
 }
 
+--- Replaces symbols into separators and colons to transform filename into a session directory.
+---@param filename string: Filename with expressions to replace.
+---@return string: Session directory
+function config.delimited_session_filename_to_dir(filename)
+  local dir = filename
+  dir = dir:sub(0, dir:find(config.colon_replacer))
+  dir = dir:gsub(config.colon_replacer, ':')
+  dir = dir:gsub(config.path_replacer, Path.path.sep)
+  return dir
+end
+
+--- Replaces separators and colons into special symbols to transform session directory into a filename.
+---@param dir string: Path to session directory.
+---@return string: Session filename.
+function config.dir_to_delimited_session_filename(dir)
+  local filename = dir
+  filename = filename:gsub(':', config.colon_replacer)
+  filename = filename:gsub(Path.path.sep, config.path_replacer)
+
+  local extras = config.extras_generator(dir)
+  if extras ~= nil then
+    filename = filename .. config.extras_separator .. extras
+  end
+
+  return filename
+end
+
 config.defaults = {
   sessions_dir = Path:new(vim.fn.stdpath('data'), 'sessions'),
   path_replacer = '__',
   colon_replacer = '++',
+  dir_to_session_filename = config.dir_to_delimited_session_filename,
+  session_filename_to_dir = config.delimited_session_filename_to_dir,
   extras_separator = '==',
   extras_generator = function (dir) return nil end,
   autoload_mode = config.AutoloadMode.LastSession,

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -138,6 +138,7 @@ function utils.session_filename_to_dir(filename)
   -- Get session filename.
   local dir = filename:sub(#tostring(config.sessions_dir) + 2)
 
+  dir = dir:sub(0, dir:find(config.colon_replacer))
   dir = dir:gsub(config.colon_replacer, ':')
   dir = dir:gsub(config.path_replacer, Path.path.sep)
   return Path:new(dir)
@@ -150,6 +151,12 @@ function utils.dir_to_session_filename(dir)
   local filename = dir and dir.filename or vim.loop.cwd()
   filename = filename:gsub(':', config.colon_replacer)
   filename = filename:gsub(Path.path.sep, config.path_replacer)
+
+  local extras = config.extras_generator(dir)
+  if extras ~= nil then
+    filename = filename .. config.extras_separator .. extras
+  end
+
   return Path:new(config.sessions_dir):joinpath(filename)
 end
 

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -135,28 +135,16 @@ end
 ---@param filename string: Filename with expressions to replace.
 ---@return table: Session directory
 function utils.session_filename_to_dir(filename)
-  -- Get session filename.
-  local dir = filename:sub(#tostring(config.sessions_dir) + 2)
-
-  dir = dir:sub(0, dir:find(config.colon_replacer))
-  dir = dir:gsub(config.colon_replacer, ':')
-  dir = dir:gsub(config.path_replacer, Path.path.sep)
-  return Path:new(dir)
+  filename = filename:sub(#tostring(config.sessions_dir) + 2)
+  return Path:new(config.session_filename_to_dir(filename))
 end
 
 --- Replaces separators and colons into special symbols to transform session directory into a filename.
 ---@param dir table?: Path to session directory. Defaults to the current working directory if `nil`.
 ---@return table: Session filename.
 function utils.dir_to_session_filename(dir)
-  local filename = dir and dir.filename or vim.loop.cwd()
-  filename = filename:gsub(':', config.colon_replacer)
-  filename = filename:gsub(Path.path.sep, config.path_replacer)
-
-  local extras = config.extras_generator(dir)
-  if extras ~= nil then
-    filename = filename .. config.extras_separator .. extras
-  end
-
+  dir = dir and dir.filename or vim.loop.cwd()
+  local filename = config.dir_to_session_filename(dir)
   return Path:new(config.sessions_dir):joinpath(filename)
 end
 


### PR DESCRIPTION
Adds a configuration hook to define "extras" that will be added as a postfix to the session file name.

Example config (that I use) for a different session for each git branch.

```
    session_manager.setup({
        autoload_mode = sm_config.AutoloadMode.Disabled, -- do not auto-load the last session at startup
        extras_generator = function(dir)
            local handle = io.popen("git branch --show-current 2>/dev/null")
            if (handle == nil) then
                return nil
            end
            local branch = handle:read("l")
            handle:close()
            if (branch == nil) then
                return nil
            end
            branch = branch:gsub("/", "++")
            return branch
        end,
    })
```