### PR TITLE
Auto save session after write buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ vim.api.nvim_create_autocmd({ 'User' }, {
 })
 ```
 
+### Save session on save buffer
+
+Save session every time a buffer is written
+```lua
+vim.api.nvim_create_autocmd({ 'BufWritePost' }, {
+  group = config_group,
+  callback = function ()
+    if vim.bo.filetype ~= 'git'
+      and not vim.bo.filetype ~= 'gitcommit'
+      then session_manager.autosave_session() end
+  end
+})
+```
+
 For more information about autocmd and its event, see also:
 
 - [`:help autocmd`](https://neovim.io/doc/user/autocmd.html)

--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ vim.api.nvim_create_autocmd({ 'User' }, {
 })
 ```
 
-### Save session on save buffer
+## Save session on save buffer
 
-Save session every time a buffer is written
+Example how to save session every time a buffer is written:
+
 ```lua
 vim.api.nvim_create_autocmd({ 'BufWritePost' }, {
   group = config_group,


### PR DESCRIPTION
This allows to restore sesions with new buffers if the nvim/parent process are suddenly killed.
Excludes gitfiles to avoid conflicts with fugitive.vim. It sames that `:mksession` doesn't go well with tabs