### PR TITLE
Create function delete_session_by_dir

### DIFF
--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -73,6 +73,17 @@ function session_manager.delete_session()
   end)
 end
 
+--- Delete a session by its directory. Used by third-party plugins
+function session_manager.delete_session_by_dir(path)
+  local sessions = utils.get_sessions()
+
+  for idx, session in ipairs(sessions) do
+    if session.dir.filename == path then
+      return Path:new(sessions[idx].filename):rm()
+    end
+  end
+end
+
 --- Saves a session based on settings. Executed before exiting the editor.
 function session_manager.autosave_session()
   if not config.autosave_last_session then

--- a/lua/session_manager/subcommands.lua
+++ b/lua/session_manager/subcommands.lua
@@ -17,7 +17,7 @@ function subcommands.complete(arg, cmd_line)
 
   if #words == 1 then
     for subcommand in pairs(session_manager) do
-      if vim.startswith(subcommand, arg) and not vim.startswith(subcommand, 'auto') and subcommand ~= 'setup' then
+      if vim.startswith(subcommand, arg) and not vim.startswith(subcommand, 'auto') and subcommand ~= 'setup' and subcommand ~= 'delete_session_by_dir' then
         table.insert(matches, subcommand)
       end
     end


### PR DESCRIPTION
I added one new useful function to the module scope. 
I need this for integration with my [project management plugin](https://github.com/coffebar/project.nvim). The feature will be: 

> when you delete a project, its saved session will be deleted as well

The existing function "delete_session" can't be used in my case, because it has additional UI.

The function I added in this PR, potentially can be used by other plugins or power users.
