### PR TITLE
Drop current session when current session file is deleted.

### DIFF
--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -67,17 +67,20 @@ end
 
 function session_manager.delete_session()
   local sessions = utils.get_sessions()
-
-  local display_names = {}
-  for _, session in ipairs(sessions) do
-    table.insert(display_names, utils.shorten_path(session.dir))
-  end
-
-  vim.ui.select(display_names, { prompt = 'Delete Session' }, function(_, idx)
-    if idx then
-      Path:new(sessions[idx].filename):rm()
-      session_manager.delete_session()
-    end
+  vim.ui.select(sessions, {
+      prompt = 'Delete Session',
+      format_item = function(item)
+        return utils.shorten_path(item.dir)
+      end
+    }, function(item)
+      if item then
+        Path:new(item.filename):rm()
+        local cwd = vim.loop.cwd()
+        if utils.is_session and cwd and item.filename == config.dir_to_session_filename(cwd).filename then
+          utils.is_session = false
+        end
+        session_manager.delete_session()
+      end
   end)
 end
 

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -68,19 +68,17 @@ end
 function session_manager.delete_session()
   local sessions = utils.get_sessions()
   vim.ui.select(sessions, {
-      prompt = 'Delete Session',
-      format_item = function(item)
-        return utils.shorten_path(item.dir)
+    prompt = 'Delete Session',
+    format_item = function(item) return utils.shorten_path(item.dir) end,
+  }, function(item)
+    if item then
+      Path:new(item.filename):rm()
+      local cwd = vim.loop.cwd()
+      if utils.is_session and cwd and item.filename == config.dir_to_session_filename(cwd).filename then
+        utils.is_session = false
       end
-    }, function(item)
-      if item then
-        Path:new(item.filename):rm()
-        local cwd = vim.loop.cwd()
-        if utils.is_session and cwd and item.filename == config.dir_to_session_filename(cwd).filename then
-          utils.is_session = false
-        end
-        session_manager.delete_session()
-      end
+      session_manager.delete_session()
+    end
   end)
 end
 


### PR DESCRIPTION
When the session file for the current session is deleted and vim is closed, the file that was just deleted is restored again if autosave is enabled.

I hope this is a proper fix. I didn't test extensively with all combinations of session manager settings.

I also slightly restructured the call to `vim.ui.select` so the intermediate table `display_names` is no longer needed. Hope you don't mind.