### PR TITLE
Implement conditional autosaving by a predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ require('session_manager').setup({
   },
   autosave_ignore_buftypes = {}, -- All buffers of these bufer types will be closed before the session is saved.
   autosave_only_in_session = false, -- Always autosaves session. If true, only autosaves after a session is active.
+  autosave_extra_predicate = nil, -- If a function is specified, execute the function and only autosave if true is returned
   max_path_length = 80,  -- Shorten the display path if length exceeds this threshold. Use 0 if don't want to shorten the path at all.
 })
 ```

--- a/lua/session_manager/config.lua
+++ b/lua/session_manager/config.lua
@@ -47,6 +47,7 @@ config.defaults = {
   },
   autosave_ignore_buftypes = {},
   autosave_only_in_session = false,
+  autosave_extra_predicate = nil,
   max_path_length = 80,
 }
 

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -93,6 +93,10 @@ function session_manager.autosave_session()
     return
   end
 
+  if config.autosave_extra_predicate and not config.autosave_extra_predicate() then
+    return
+  end
+
   if not config.autosave_ignore_not_normal or utils.is_restorable_buffer_present() then
     session_manager.save_current_session()
   end


### PR DESCRIPTION
This PR introduces a new config option, `autosave_extra_predicate` which if specified will be executed before an autosave happens. If the function does not return `true`, the autosave is cancelled.

Example lazy.nvim configuration I have for not autosaving when there's only a single buffer open:
```lua
return {
  "shebpamm/neovim-session-manager", 
  event = "VimEnter",
  config = function()
    local s = require "session_manager"
    local sc = require "session_manager.config"

    s.setup {
      autoload_mode = sc.AutoloadMode.Disabled,
      autosave_extra_predicate = function()
        return #vim.fn.getbufinfo { buflisted = 1 } > 1
      end,
    }
  end,
}
``` 

Two things I'd like input on:
1. `autosave_extra_predicate` could perhaps have a more descriptive name
2. Should we check that the value is a function rather than just not `nil`? If so, what should happen if the value is something other than a function or nil?  