### PR TITLE
Make help buffers restorable

### DIFF
--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -140,8 +140,8 @@ function utils.is_restorable(buffer)
     if #vim.api.nvim_buf_get_name(buffer) == 0 then
       return false
     end
-  elseif buftype ~= 'terminal' then
-    -- Buffers other then normal or terminal are impossible to restore.
+  elseif buftype ~= 'terminal' and buftype ~= 'help' then
+    -- Buffers other then normal, terminal and help are impossible to restore.
     return false
   end
 


### PR DESCRIPTION
Neovim can restore help buffers if `sessionoptions` includes the value `help`. This change makes `help` buffers be reported as restorable and, as such, included in session management.

See also the Neovim docs for [sessionoptions](https://neovim.io/doc/user/options.html#'sessionoptions').