### PR TITLE
hotfix(#98): Patch for the autocmd to save session on BufWrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,23 +74,16 @@ vim.api.nvim_create_autocmd({ 'User' }, {
 })
 ```
 
-## Save session on save buffer
-
-Example how to save session every time a buffer is written:
-
+## Save session on BufWrite
+You can enable this opt in feature with
 ```lua
+-- Auto save session
 vim.api.nvim_create_autocmd({ 'BufWritePre' }, {
   callback = function ()
-    -- HOTFIX: Disable autosave while there is a nofile buffer open.
-    -- This won't be necessary once this neovim bug has been solved:
-    -- https://github.com/Shatur/neovim-session-manager/issues/98
+    -- Don't save while there's any 'nofile' buffer open.
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
       local buftype = vim.api.nvim_buf_get_option(buf, 'buftype')
-      if buftype == 'nofile' then vim.notify(
-          "Current session won't we auto-saved until you close all 'nofile' buffers.",
-          vim.log.levels.INFO, { title = "neovim-session-manager" })
-          return
-      end
+      if buftype == 'nofile' then return end
     end
     session_manager.save_current_session()
   end

--- a/README.md
+++ b/README.md
@@ -75,15 +75,18 @@ vim.api.nvim_create_autocmd({ 'User' }, {
 ```
 
 ## Save session on BufWrite
+
 You can enable this opt in feature with
+
 ```lua
 -- Auto save session
 vim.api.nvim_create_autocmd({ 'BufWritePre' }, {
   callback = function ()
-    -- Don't save while there's any 'nofile' buffer open.
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-      local buftype = vim.api.nvim_get_option_value("buftype", { buf = buf })
-      if buftype == 'nofile' then return end
+      -- Don't save while there's any 'nofile' buffer open.
+      if vim.api.nvim_get_option_value("buftype", { buf = buf }) == 'nofile' then
+        return
+      end
     end
     session_manager.save_current_session()
   end

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ vim.api.nvim_create_autocmd({ 'BufWritePre' }, {
   callback = function ()
     -- Don't save while there's any 'nofile' buffer open.
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-      local buftype = vim.api.nvim_buf_get_option(buf, 'buftype')
+      local buftype = vim.api.nvim_get_option_value("buftype", { buf = buf })
       if buftype == 'nofile' then return end
     end
     session_manager.save_current_session()


### PR DESCRIPTION
If there is any `nofile` buffer in the buffer list, it will show a notification instead of forcefully closing the buffers.

![screenshot_2023-10-09_16-20-27_694529706](https://github.com/Shatur/neovim-session-manager/assets/3357792/3c190ef3-a394-4967-81ec-1a7a54972b28)

This approach make `git mergetool`, `neotree`, `aerial` and others usable again, while keeping the advantages of session autosave, for the most part.

This is the best we can achieve until [this neovim bug](https://github.com/Shatur/neovim-session-manager/issues/98) is fixed.