### PR TITLE
feature: delete current dir session

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ The plugin saves the sessions in the specified folder (see [configuration](#conf
 
 Use the command `:SessionManager[!]` with one of the following arguments:
 
-| Argument                   | Description                                                                                  |
-| -------------------------- | -------------------------------------------------------------------------------------------- |
-| `load_session`             | Select and load session. (Your current session won't appear on the list).                    |
-| `load_last_session`        | Will remove all buffers and `:source` the last saved session.                                |
-| `load_current_dir_session` | Will remove all buffers and `:source` the last saved session file of the current dirtectory. |
-| `save_current_session`     | Works like `:mksession`, but saves/creates current directory as a session in `sessions_dir`. |
-| `delete_session`           | Select and delete session.                                                                   |
+| Argument                     | Description                                                                                  |
+| -----------------------------| -------------------------------------------------------------------------------------------- |
+| `load_session`               | Select and load session. (Your current session won't appear on the list).                    |
+| `load_last_session`          | Will remove all buffers and `:source` the last saved session.                                |
+| `load_current_dir_session`   | Will remove all buffers and `:source` the last saved session file of the current dirtectory. |
+| `save_current_session`       | Works like `:mksession`, but saves/creates current directory as a session in `sessions_dir`. |
+| `delete_session`             | Select and delete session.                                                                   |
+| `delete_current_dir_sesssion`| Deletes the session associated with the current directory.                                   |
 
 When `!` is specified, the modified buffers will not be saved.
 

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -69,11 +69,7 @@ function session_manager.delete_session()
     format_item = function(item) return utils.shorten_path(item.dir) end,
   }, function(item)
     if item then
-      Path:new(item.filename):rm()
-      local cwd = vim.loop.cwd()
-      if utils.is_session and cwd and item.filename == config.dir_to_session_filename(cwd).filename then
-        utils.is_session = false
-      end
+      utils.delete_session(item.filename)
       session_manager.delete_session()
     end
   end)

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -75,6 +75,17 @@ function session_manager.delete_session()
   end)
 end
 
+--- Deletes the session for the current working directory.
+function session_manager.delete_current_dir_session()
+  local cwd = vim.loop.cwd()
+  if cwd then
+    local session = config.dir_to_session_filename(cwd)
+    if session:exists() then
+      utils.delete_session(session)
+    end
+  end
+end
+
 --- Saves a session based on settings. Executed before exiting the editor.
 function session_manager.autosave_session()
   if not config.autosave_last_session then

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -93,6 +93,15 @@ function utils.save_session(filename)
   vim.api.nvim_exec_autocmds('User', { pattern = 'SessionSavePost' })
 end
 
+---@param filename string
+function utils.delete_session(filename)
+  Path:new(filename):rm()
+  local cwd = vim.loop.cwd()
+  if utils.is_session and cwd and filename == config.dir_to_session_filename(cwd).filename then
+    utils.is_session = false
+  end
+end
+
 ---@return table
 function utils.get_sessions()
   local sessions = {}


### PR DESCRIPTION
Fixes: #104

Adds a `delete_current_dir_session` command.

A caveat to this command is that if `autosave` is turned on, it will end up saving the session again on exit. A simple work around for this is to delete all the buffers (e.g. `:bufdo bd`) before running the command.
I think there may be a way around this, but feel it's out of scope of this PR.