### PR TITLE
Disable session-saving on empty buffers

### DIFF
--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -64,7 +64,9 @@ end
 function session_manager.save_current_session()
   local cwd = vim.loop.cwd()
   if cwd then
-    utils.save_session(config.dir_to_session_filename(cwd).filename)
+    if vim.api.nvim_buf_get_option(0, 'buftype') ~= 'nofile' then
+      utils.save_session(config.dir_to_session_filename(cwd).filename)
+    end
   end
 end
 


### PR DESCRIPTION
I've been having the same issue from #46, which has caused my dashboard to not open when the session has been saved on an empty buffer. As a solution, we can skip saving the session if the buffer is empty.

Currently, this PR only checks for the first buffer, but we can loop over all of them like in the [auto-save example](https://github.com/eljamm/neovim-session-manager#save-session-on-bufwrite).
