### PR TITLE
automatically saved when the current working directory is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ require('session_manager').setup({
   session_filename_to_dir = session_filename_to_dir, -- Function that replaces symbols into separators and colons to transform filename into a session directory.
   dir_to_session_filename = dir_to_session_filename, -- Function that replaces separators and colons into special symbols to transform session directory into a filename. Should use `vim.loop.cwd()` if the passed `dir` is `nil`.
   autoload_mode = config.AutoloadMode.LastSession, -- Define what to do when Neovim is started without arguments. Possible values: Disabled, CurrentDir, LastSession
-  autosave_last_session = true, -- Automatically save last session on exit and on session switch.
+  autosave_last_session = true, -- Automatically save last session on exit or current working dictionary changed and on session switch.
   autosave_ignore_not_normal = true, -- Plugin will not save a session when no buffers are opened, or all of them aren't writable or listed.
   autosave_ignore_dirs = {}, -- A list of directories where the session will not be autosaved.
   autosave_ignore_filetypes = { -- All buffers of these file types will be closed before the session is saved.

--- a/plugin/session_manager.lua
+++ b/plugin/session_manager.lua
@@ -14,7 +14,7 @@ vim.api.nvim_create_autocmd({ 'VimEnter' }, {
   nested = true,
   callback = session_manager.autoload_session,
 })
-vim.api.nvim_create_autocmd({ 'VimLeavePre' }, {
+vim.api.nvim_create_autocmd({ 'VimLeavePre', 'DirChangedPre' }, {
   group = session_manager_group,
   callback = session_manager.autosave_session,
 })


### PR DESCRIPTION
When the current working directory changes, it is obvious that the previous modifications to the session corresponding to the working directory should be saved (my personal opinion)
I think it will be easier to use after adding