### PR TITLE
added silent option in utils.get_sessions

### DIFF
--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -99,10 +99,11 @@ function utils.delete_session(filename)
   end
 end
 
+---@param opts table?: Additional arguments. Currently only `silent` is supported.
 ---@return table
-function utils.get_sessions()
+function utils.get_sessions(opts)
   local sessions = {}
-  for _, session_filename in ipairs(scandir.scan_dir(tostring(config.sessions_dir))) do
+  for _, session_filename in ipairs(scandir.scan_dir(tostring(config.sessions_dir), opts)) do
     local dir = config.session_filename_to_dir(session_filename)
     if dir:is_dir() then
       table.insert(sessions, { timestamp = vim.fn.getftime(session_filename), filename = session_filename, dir = dir })
@@ -122,7 +123,7 @@ function utils.get_sessions()
   end
 
   -- If no sessions to list, send a notification.
-  if #sessions == 0 then
+  if not(opts and opts.silent) and #sessions == 0 then
     vim.notify('The only available session is your current session. Nothing to select from.', vim.log.levels.INFO)
   end
 

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -123,7 +123,7 @@ function utils.get_sessions(opts)
   end
 
   -- If no sessions to list, send a notification.
-  if not(opts and opts.silent) and #sessions == 0 then
+  if not (opts and opts.silent) and #sessions == 0 then
     vim.notify('The only available session is your current session. Nothing to select from.', vim.log.levels.INFO)
   end
 


### PR DESCRIPTION
Trying to solve #118. 

Added a `silent` option to `session_manager.utils.get_sessions` which will suppress the print messages and notifications. 

**Justification**
The [`scan_dir`](https://github.com/nvim-lua/plenary.nvim/blob/master/lua/plenary/scandir.lua#L162) function used in [`utils.lua:L105`](https://github.com/Shatur/neovim-session-manager/blob/master/lua/session_manager/utils.lua#L105) already supports a `silent` option to pass in for silence. Adding an option in `get_sessions` simply passes the option to `scan_dir` and at the same time is applied to the function itself.

This will not affect the behavior of `get_sessions` in other places as well because the `opts` argument is totally optional.