### PR TITLE
F/ordered autoload

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ require('session_manager').setup({
   sessions_dir = Path:new(vim.fn.stdpath('data'), 'sessions'), -- The directory where the session files will be saved.
   session_filename_to_dir = session_filename_to_dir, -- Function that replaces symbols into separators and colons to transform filename into a session directory.
   dir_to_session_filename = dir_to_session_filename, -- Function that replaces separators and colons into special symbols to transform session directory into a filename. Should use `vim.uv.cwd()` if the passed `dir` is `nil`.
-  autoload_mode = config.AutoloadMode.LastSession, -- Define what to do when Neovim is started without arguments. Possible values: Disabled, CurrentDir, LastSession
+  autoload_mode = config.AutoloadMode.LastSession, -- Define what to do when Neovim is started without arguments. 
   autosave_last_session = true, -- Automatically save last session on exit and on session switch.
   autosave_ignore_not_normal = true, -- Plugin will not save a session when no buffers are opened, or all of them aren't writable or listed.
   autosave_ignore_dirs = {}, -- A list of directories where the session will not be autosaved.
@@ -49,6 +49,26 @@ require('session_manager').setup({
   max_path_length = 80,  -- Shorten the display path if length exceeds this threshold. Use 0 if don't want to shorten the path at all.
 })
 ```
+
+### Autoload mode
+
+If Neovim is started without arguments the value of the autoload_mode option is used to determine which session to initially load. The following modes are supported:
+
+| Mode | Description |
+| --- | --- |
+| Disabled | No session will be loaded. |
+| CurrentDir | The session in the current working directory will be loaded. |
+| LastSession | The last session will be loaded. This is the default.|
+
+Autoload_mode can be set to either a single mode or an array of modes, in which
+case each mode will be tried until one succeeds e.g.
+
+```
+autoload_mode = { config.AutoloadMode.CurrentDir, config.AutoloadMode.LastSession }
+```
+
+Would attempt to load the current directory session and then fallback to the last session.
+
 
 ## Autocommands
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Use the command `:SessionManager[!]` with one of the following arguments:
 | Argument                     | Description                                                                                  |
 | -----------------------------| -------------------------------------------------------------------------------------------- |
 | `load_session`               | Select and load session. (Your current session won't appear on the list).                    |
-| `load_last_session`          | Will remove all buffers and `:source` the last saved session.                                |
-| `load_current_dir_session`   | Will remove all buffers and `:source` the last saved session file of the current directory.  |
+| `load_last_session`          | Will remove all buffers and `:source` the last saved session. (returns true if the session was restored and false otherwise) |
+| `load_current_dir_session`   | Will remove all buffers and `:source` the last saved session file of the current directory. (returns true if the session was restored and false otherwise) |
 | `save_current_session`       | Works like `:mksession`, but saves/creates current directory as a session in `sessions_dir`. |
 | `delete_session`             | Select and delete session.                                                                   |
 | `delete_current_dir_session`| Deletes the session associated with the current directory.                                   |

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ The plugin saves the sessions in the specified folder (see [configuration](#conf
 
 Use the command `:SessionManager[!]` with one of the following arguments:
 
-| Argument                     | Description                                                                                  |
-| -----------------------------| -------------------------------------------------------------------------------------------- |
-| `load_session`               | Select and load session. (Your current session won't appear on the list).                    |
-| `load_last_session`          | Will remove all buffers and `:source` the last saved session. (returns true if the session was restored and false otherwise) |
-| `load_current_dir_session`   | Will remove all buffers and `:source` the last saved session file of the current directory. (returns true if the session was restored and false otherwise) |
-| `save_current_session`       | Works like `:mksession`, but saves/creates current directory as a session in `sessions_dir`. |
-| `delete_session`             | Select and delete session.                                                                   |
-| `delete_current_dir_session`| Deletes the session associated with the current directory.                                   |
+| Argument                     | Description                                                                                                                                                        |
+| -----------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `load_session`               | Select and load session. (Your current session won't appear on the list).                                                                                          |
+| `load_last_session`          | Removes all buffers and tries to `:source` the last saved session. Returns `true` if the session was restored and `false` otherwise.                               |
+| `load_current_dir_session`   | Removes all buffers and tries to `:source` the last saved session file of the current directory. Returns `true` if the session was restored and `false` otherwise. |
+| `save_current_session`       | Works like `:mksession`, but saves/creates current directory as a session in `sessions_dir`.                                                                       |
+| `delete_session`             | Select and delete session.                                                                                                                                         |
+| `delete_current_dir_session` | Deletes the session associated with the current directory.                                                                                                         |
 
 When `!` is specified, the modified buffers will not be saved.
 
@@ -36,7 +36,7 @@ require('session_manager').setup({
   sessions_dir = Path:new(vim.fn.stdpath('data'), 'sessions'), -- The directory where the session files will be saved.
   session_filename_to_dir = session_filename_to_dir, -- Function that replaces symbols into separators and colons to transform filename into a session directory.
   dir_to_session_filename = dir_to_session_filename, -- Function that replaces separators and colons into special symbols to transform session directory into a filename. Should use `vim.uv.cwd()` if the passed `dir` is `nil`.
-  autoload_mode = config.AutoloadMode.LastSession, -- Define what to do when Neovim is started without arguments. 
+  autoload_mode = config.AutoloadMode.LastSession, -- Define what to do when Neovim is started without arguments. See "Autoload mode" section below.
   autosave_last_session = true, -- Automatically save last session on exit and on session switch.
   autosave_ignore_not_normal = true, -- Plugin will not save a session when no buffers are opened, or all of them aren't writable or listed.
   autosave_ignore_dirs = {}, -- A list of directories where the session will not be autosaved.
@@ -54,16 +54,16 @@ require('session_manager').setup({
 
 If Neovim is started without arguments the value of the autoload_mode option is used to determine which session to initially load. The following modes are supported:
 
-| Mode | Description |
-| --- | --- |
-| Disabled | No session will be loaded. |
-| CurrentDir | The session in the current working directory will be loaded. |
-| LastSession | The last session will be loaded. This is the default.|
+| Mode        | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| Disabled    | No session will be loaded.                                   |
+| CurrentDir  | The session in the current working directory will be loaded. |
+| LastSession | The last session will be loaded. This is the default.        |
 
-Autoload_mode can be set to either a single mode or an array of modes, in which
+`autoload_mode` can be set to either a single mode or an array of modes, in which
 case each mode will be tried until one succeeds e.g.
 
-```
+```lua
 autoload_mode = { config.AutoloadMode.CurrentDir, config.AutoloadMode.LastSession }
 ```
 

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -72,20 +72,6 @@ function session_manager.save_current_session()
   end
 end
 
-local get_autoload_mode = function()
-  if config.autoload_mode == AutoloadMode.Disabled or
-      vim.fn.argc() > 0
-      or vim.g.started_with_stdin then
-    return { AutoloadMode.Disabled }
-  end
-  if config.autoload_mode == AutoloadMode.CurrentDir or
-      config.autoload_mode == AutoloadMode.LastSession then
-    -- Don't break existing configurations
-    return { config.autoload_mode }
-  end
-  return config.autoload_mode
-end
-
 local autoloaders = {
   [AutoloadMode.Disabled] = function() return true end,
   [AutoloadMode.CurrentDir] = session_manager.load_current_dir_session,
@@ -94,7 +80,14 @@ local autoloaders = {
 
 --- Loads a session based on settings. Executed after starting the editor.
 function session_manager.autoload_session()
-  for _, mode in ipairs(get_autoload_mode()) do
+  if vim.fn.argc() > 0 or vim.g.started_with_stdin then
+    return
+  end
+  local modes = config.autoload_mode
+  if not vim.isarray(config.autoload_mode) then
+    modes = { config.autoload_mode }
+  end
+  for _, mode in ipairs(modes) do
     if autoloaders[mode]() then
       return
     end

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -46,7 +46,9 @@ function session_manager.load_last_session(discard_current)
   local last_session = utils.get_last_session_filename()
   if last_session then
     utils.load_session(last_session, discard_current)
+    return true
   end
+  return false
 end
 
 --- Loads a session for the current working directory.
@@ -56,8 +58,10 @@ function session_manager.load_current_dir_session(discard_current)
     local session = config.dir_to_session_filename(cwd)
     if session:exists() then
       utils.load_session(session.filename, discard_current)
+      return true
     end
   end
+  return false
 end
 
 --- Saves a session for the current working directory.
@@ -69,10 +73,14 @@ function session_manager.save_current_session()
 end
 
 local get_autoload_mode = function()
-  if config.autoload_mode == nil or vim.fn.argc() > 0 or vim.g.started_with_stdin then
+  if config.autoload_mode == AutoloadMode.Disabled or
+      vim.fn.argc() > 0
+      or vim.g.started_with_stdin then
     return { AutoloadMode.Disabled }
   end
-  if type(config.autoload_mode) ~= 'table' then
+  if config.autoload_mode == AutoloadMode.CurrentDir or
+      config.autoload_mode == AutoloadMode.LastSession then
+    -- Don't break existing configurations
     return { config.autoload_mode }
   end
   return config.autoload_mode

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -40,7 +40,7 @@ function session_manager.load_session(discard_current)
   end)
 end
 
---- Loads saved used session.
+--- Tries to load the last saved session.
 ---@param discard_current boolean?: If `true`, do not check for unsaved buffers.
 ---@return boolean: `true` if session was loaded, `false` otherwise.
 function session_manager.load_last_session(discard_current)
@@ -52,7 +52,7 @@ function session_manager.load_last_session(discard_current)
   return false
 end
 
---- Loads a session for the current working directory.
+--- Tries to load a session for the current working directory.
 ---@return boolean: `true` if session was loaded, `false` otherwise.
 function session_manager.load_current_dir_session(discard_current)
   local cwd = vim.uv.cwd()
@@ -85,10 +85,12 @@ function session_manager.autoload_session()
   if vim.fn.argc() > 0 or vim.g.started_with_stdin then
     return
   end
+
   local modes = config.autoload_mode
   if not vim.isarray(config.autoload_mode) then
     modes = { config.autoload_mode }
   end
+
   for _, mode in ipairs(modes) do
     if autoloaders[mode]() then
       return

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -42,6 +42,7 @@ end
 
 --- Loads saved used session.
 ---@param discard_current boolean?: If `true`, do not check for unsaved buffers.
+---@return boolean: `true` if session was loaded, `false` otherwise.
 function session_manager.load_last_session(discard_current)
   local last_session = utils.get_last_session_filename()
   if last_session then
@@ -52,6 +53,7 @@ function session_manager.load_last_session(discard_current)
 end
 
 --- Loads a session for the current working directory.
+---@return boolean: `true` if session was loaded, `false` otherwise.
 function session_manager.load_current_dir_session(discard_current)
   local cwd = vim.uv.cwd()
   if cwd then


### PR DESCRIPTION
Hi there, this is a pull request for the [issue](https://github.com/Shatur/neovim-session-manager/issues/123) I raised. This should allow users to specify mutliple auotload options and on startup each will be tried in order until one succeds. 

I had considered adding a new startup option that looked to see if the current directory had a session associated with it and if not use the last session but I saw someone else had submitted a pull request for git sessions and I thought a list of options would be more compatible with that.

I've not really done any work with lua before so apologies if it is a little un-idiomatic, I'm happy to tidy it up however you like

I've alos tried to make it so the change won't break any existing configurations

