### PR TITLE
Track active session and use it to determine `exists_in_session`

### DIFF
--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -149,7 +149,7 @@ function session_manager.autosave_session()
     return
   end
 
-  if config.autosave_only_in_session and not utils.is_exist_in_session() then
+  if config.autosave_only_in_session and not utils.exists_in_session() then
     return
   end
 


### PR DESCRIPTION
This PR was created to resolve the issues discussed in #122 (see the comments after the PR was merged), but I just noticed it solves another small bug as well...

Currently when you open vim (with `autoload_mode` disabled) from a directory for which a session exists and you run `:SessionManager load_session` it will omit the session for the current directory even if that session isn't actually loaded (which prevents you to load the session this way). This is also solved but this PR.