### PR TITLE
Fix: Show error when neovim < 0.10

### DIFF
--- a/plugin/session_manager.lua
+++ b/plugin/session_manager.lua
@@ -1,4 +1,4 @@
-if not vim.fn.has('nvim-0.10.0') then
+if vim.fn.has('nvim-0.10.0') == 0 then
   require('session_manager.utils').notify('Neovim 0.10+ is required for session manager plugin', vim.log.levels.ERROR)
   return
 end


### PR DESCRIPTION
Current implementation always returns false, so people who use older version of nvim only see random errors instead of a proper explanation. This patch makes it work correctly.