### PR TITLE
Clear the active session on `delete_current_dir_session`

### DIFF
--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -138,12 +138,7 @@ function session_manager.delete_current_dir_session()
   if cwd then
     local session = config.dir_to_session_filename(cwd)
     if session:exists() then
-      utils.delete_session(session)
-
-      -- Clear the active session filename if deleted.
-      if session.filename == utils.active_session_filename then
-        utils.active_session_filename = nil
-      end
+      utils.delete_session(session.filename)
     end
   end
 end

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -139,6 +139,11 @@ function session_manager.delete_current_dir_session()
     local session = config.dir_to_session_filename(cwd)
     if session:exists() then
       utils.delete_session(session)
+
+      -- Clear the active session filename if deleted.
+      if session.filename == utils.active_session_filename then
+        utils.active_session_filename = nil
+      end
     end
   end
 end


### PR DESCRIPTION
This will make `autosave_only_in_session=true` not save a previously deleted session on exit when it's deleted via `delete_current_dir_session`.