### PR TITLE
feat: add func to check if a session in cwd exists

### DIFF
--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -67,6 +67,17 @@ function session_manager.load_current_dir_session(discard_current)
   return false
 end
 
+--- Checks if a session for the current working directory exists.
+---@return boolean: `true` if session was found, `false` otherwise.
+function session_manager.current_dir_session_exists()
+  local cwd = vim.uv.cwd()
+  if cwd then
+    local session = config.dir_to_session_filename(cwd)
+    return session:exists()
+  end
+  return false
+end
+
 --- If in a git repo, tries to load a session for the repo's root directory
 ---@return boolean: `true` if session was loaded, `false` otherwise.
 function session_manager.load_git_session(discard_current)


### PR DESCRIPTION
Added a simple function to check if a session for the cwd exists. My use case for it is to conditionally show an option on my startup dashboard to load the session for the cwd. 

For example:

```lua
local get_actions = function()
  local actions = {
    { action = "Telescope find_files", desc = " find file", icon = " ", key = "f", },
    { action = "Telescope oldfiles cwd_only=true", desc = " recent files", icon = " ", key = "r", },
    { action = "Oil", desc = " explorer", icon = "󱏒 ", key = "e", },
    { action = "Telescope live_grep", desc = " grep", icon = " ", key = "g", },
    { action = "Lazy", desc = " lazy", icon = "󰒲 ", key = "l", },
    { action = function() vim.api.nvim_input("<cmd>qa<cr>") end, desc = " quit", icon = " ", key = "q", },
  }

  if require("session_manager").current_dir_session_exists() then
    table.insert(actions, 5, {
      action = "SessionManager load_current_dir_session",
      desc = " restore session",
      icon = " ",
      key = "s",
    })
  end

  if require("cmill.core.util").is_git_repo() then
    table.insert(
      actions,
      5,
      { action = "Neogit", desc = " git", icon = " ", key = "G" }
    )
  end
  return actions
end

return {
  {
    "nvimdev/dashboard-nvim",
    -- snip --
        config = {
          center = get_actions(),
    -- snip --
```