### PR TITLE
feat: add option to include the current session in load_session UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ require('session_manager').setup({
   autosave_ignore_buftypes = {}, -- All buffers of these bufer types will be closed before the session is saved.
   autosave_only_in_session = false, -- Always autosaves session. If true, only autosaves after a session is active.
   max_path_length = 80,  -- Shorten the display path if length exceeds this threshold. Use 0 if don't want to shorten the path at all.
-  load_include_current = false,  -- The currently loaded session appears in the load_session UI
+  load_include_current = false,  -- The currently loaded session appears in the load_session UI.
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The plugin saves the sessions in the specified folder (see [configuration](#conf
 Use the command `:SessionManager[!]` with one of the following arguments:
 
 | Argument                     | Description                                                                                                                                                                             |
-| -----------------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `load_session`               | Select and load session. (Your current session won't appear on the list).                                                                                                               |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `load_session`               | Select and load session. (Your current session won't appear on the list by default, see configuration below).                                                                           |
 | `load_last_session`          | Removes all buffers and tries to `:source` the last saved session. Returns `true` if the session was restored and `false` otherwise.                                                    |
 | `load_current_dir_session`   | Removes all buffers and tries to `:source` the last saved session of the current directory. Returns `true` if the session was restored and `false` otherwise.                           |
 | `load_git_session`           | When in a git repo, removes all buffers and tries to `:source` the last saved session of the git repo root directory. Returns `true` if the session was restored and `false` otherwise. |
@@ -48,6 +48,7 @@ require('session_manager').setup({
   autosave_ignore_buftypes = {}, -- All buffers of these bufer types will be closed before the session is saved.
   autosave_only_in_session = false, -- Always autosaves session. If true, only autosaves after a session is active.
   max_path_length = 80,  -- Shorten the display path if length exceeds this threshold. Use 0 if don't want to shorten the path at all.
+  load_include_current = false,  -- The currently loaded session appears in the load_session UI
 })
 ```
 
@@ -70,7 +71,6 @@ autoload_mode = { config.AutoloadMode.CurrentDir, config.AutoloadMode.LastSessio
 ```
 
 Would attempt to load the current directory session and then fallback to the last session.
-
 
 ## Autocommands
 

--- a/lua/session_manager/config.lua
+++ b/lua/session_manager/config.lua
@@ -49,6 +49,7 @@ config.defaults = {
   autosave_ignore_buftypes = {},
   autosave_only_in_session = false,
   max_path_length = 80,
+  load_include_current = false,
 }
 
 setmetatable(config, { __index = config.defaults })

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -35,7 +35,7 @@ function session_manager.load_session(discard_current)
     format_item = function(item) return utils.shorten_path(item.dir) end,
   }, function(item)
     if item then
-      -- if re-loading the current session, do not save it before
+      -- If re-loading the current session, do not save it before.
       if item.filename ~= utils.active_session_filename then
         session_manager.autosave_session()
       end

--- a/lua/session_manager/init.lua
+++ b/lua/session_manager/init.lua
@@ -26,7 +26,7 @@ function session_manager.available_commands()
   end)
 end
 
---- Selects a session a loads it.
+--- Selects a session and loads it.
 ---@param discard_current boolean: If `true`, do not check for unsaved buffers.
 function session_manager.load_session(discard_current)
   local sessions = utils.get_sessions()
@@ -35,7 +35,10 @@ function session_manager.load_session(discard_current)
     format_item = function(item) return utils.shorten_path(item.dir) end,
   }, function(item)
     if item then
-      session_manager.autosave_session()
+      -- if re-loading the current session, do not save it before
+      if item.filename ~= utils.active_session_filename then
+        session_manager.autosave_session()
+      end
       utils.load_session(item.filename, discard_current)
     end
   end)

--- a/lua/session_manager/utils.lua
+++ b/lua/session_manager/utils.lua
@@ -110,7 +110,7 @@ function utils.get_sessions(opts)
   local sessions = {}
   for _, session_filename in ipairs(scandir.scan_dir(tostring(config.sessions_dir), opts)) do
     -- Add all but the active session to the list.
-    if session_filename ~= utils.active_session_filename then
+    if config.load_include_current or session_filename ~= utils.active_session_filename then
       local dir = config.session_filename_to_dir(session_filename)
       if dir:is_dir() then
         table.insert(sessions, { timestamp = vim.fn.getftime(session_filename), filename = session_filename, dir = dir })


### PR DESCRIPTION
Added the option load_include_current, which defaults to false, to allow the currently opened session to be included in the load_session selection. 

## Use Case
This use case may be very specific to me. I often find myself straying from the files in the initial sesssion, such as changing something in my config while in a session specific to another project, and I end up doing entirely different things in buffers unrelated to the original project session.

## Solution
- The previously loaded session appears in the load_session UI if the new config option, load_include_current (should probably be renamed to something more succinct)
- When re-loading the same session, it is not saved before reloading (as is usually the case when switching sessions), so I get back to where I started

